### PR TITLE
add `toBeAnInstanceOf` matcher [WIP]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# v0.1.7
+# v0.1.7 (2014-06-02)
 
 - Update the `toThrowWith` matcher to accept a pattern to match the message
+- Update the `toThrowWith` matcher to accept the expected class of a thrown exception
+- Add a `toBeAnInstanceOf(type)` matcher
 - Add `toBeTrue` and `toBeFalse` matchers
+
+The `toBeAnInstanceOf` matcher and the `anInstanceOf` parameter have been added because Dart2JS does not fully implement mirrors (in particular, it does not support `isSubtypeOf`, which is used by `toBeA` and `toThrowWith(type:)`), the `toBeAnInstanceOf` matcher and the `anInstanceOf` parameter have been added. See API docs for more information.
 
 # v0.1.6 (2014-05-28)
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ These are a few examples:
     expect(2).toBe(2);
     expect(()=> throw "BOOM").toThrow();
     expect(()=> throw "BOOM").toThrow("BOOM");
+    expect(()=> throw "Invalid Argument").toThrowWith(message: "Invalid");
+    expect(()=> throw new InvalidArgument()).toThrowWith(anInstanceOf: InvalidArgument);
+    expect(()=> throw new InvalidArgument()).toThrowWith(type: ArgumentException);
     expect(false).toBeFalsy();
     expect(null).toBeFalsy();
     expect(true).toBeTruthy();

--- a/example/example.dart
+++ b/example/example.dart
@@ -3,6 +3,9 @@ library example;
 import 'package:guinness/guinness_html.dart';
 import 'dart:html';
 
+class TestClass {
+}
+
 main(){
   guinnessEnableHtmlMatchers();
 
@@ -12,9 +15,13 @@ main(){
       expect([1,2]).toContain(2);
       expect(2).toBe(2);
       expect(2).toBeA(num);
+      expect(new TestClass()).toBeAnInstanceOf(TestClass);
+      expect("sfs").not.toBeAnInstanceOf(TestClass);
       expect(()=> throw "BOOM").toThrowWith();
       expect(()=> throw "BOOM").toThrowWith(message: "BOOM");
       expect(()=> throw "BOOM").toThrowWith(message: new RegExp("B[O]{2}M"));
+      expect(()=> throw new TestClass()).toThrowWith(anInstanceOf: TestClass);
+      expect(()=> throw new TestClass()).toThrowWith(type: TestClass);
       expect(false).toBeFalsy();
       expect(null).toBeFalsy();
       expect(true).toBeTruthy();

--- a/lib/src/common/expect.dart
+++ b/lib/src/common/expect.dart
@@ -10,10 +10,48 @@ class Expect {
   void toEqual(expected) => _m.toEqual(actual, expected);
   void toContain(expected) => _m.toContain(actual, expected);
   void toBe(expected) => _m.toBe(actual, expected);
+
+  /**
+   * Checks that an object is a subtype of `expected`.
+   *
+   * # Examples
+   *
+   *    expect(new Employee()).toBeA(Employee);
+   *    expect(new Employee()).toBeA(Person);
+   */
   void toBeA(expected) => _m.toBeA(actual, expected);
+
+  /**
+   * Checks that an object is an instance of `expected`.
+   *
+   * # Examples
+   *
+   *    expect(new Employee()).toBeAnInstanceOf(Employee);
+   *    expect(new Employee()).not.toBeAnInstanceOf(Person);
+   */
+  void toBeAnInstanceOf(expected) => _m.toBeAnInstanceOf(actual, expected);
+
   @Deprecated("toThrow() API is going to change to conform with toThrowWith()")
   void toThrow([message]) => _m.toThrow(actual, message);
-  void toThrowWith({Type type, Pattern message}) => _m.toThrowWith(actual, type: type, message: message);
+
+  /**
+   * Checks that `actual` throws an exception.
+   *
+   * When given parameters, additionally checks that:
+   *
+   * - anInstanceOf: the thrown exception is an instance of `anInstanceOf`.
+   * - type: the thrown exception is a subtype of `type`.
+   * - message: the thrown exception's message matches the provided pattern.
+   *
+   * # Examples
+   *
+   *    expect(()=> throw "Invalid Argument").toThrowWith(message: "Invalid");
+   *    expect(()=> throw new InvalidArgument()).toThrowWith(anInstanceOf: InvalidArgument);
+   *    expect(()=> throw new InvalidArgument()).toThrowWith(type: ArgumentException);
+   */
+  void toThrowWith({Type anInstanceOf, Type type, Pattern message}) =>
+      _m.toThrowWith(actual, anInstanceOf: anInstanceOf, type: type, message: message);
+
   void toBeFalsy() => _m.toBeFalsy(actual);
   void toBeTruthy() => _m.toBeTruthy(actual);
   void toBeFalse() => _m.toBeFalse(actual);
@@ -40,6 +78,7 @@ class NotExpect {
   void toContain(expected) => _m.notToContain(actual, expected);
   void toBe(expected) => _m.notToBe(actual, expected);
   void toBeA(expected) => _m.notToBeA(actual, expected);
+  void toBeAnInstanceOf(expected) => _m.notToBeAnInstanceOf(actual, expected);
   void toThrow() => _m.toReturnNormally(actual);
   void toBeDefined() => _m.toBeUndefined(actual);
   void toHaveBeenCalled() => _m.notToHaveBeenCalled(actual);

--- a/lib/src/common/interfaces.dart
+++ b/lib/src/common/interfaces.dart
@@ -16,9 +16,10 @@ abstract class Matchers {
   void toContain(actual, expected);
   void toBe(actual, expected);
   void toBeA(actual, expected);
+  void toBeAnInstanceOf(actual, expected);
   @Deprecated("toThrow() API is going to change to conform with toThrowWith()")
   void toThrow(actual, message);
-  void toThrowWith(actual, {Type type, Pattern message});
+  void toThrowWith(actual, {Type anInstanceOf, Type type, Pattern message});
   void toBeFalsy(actual);
   void toBeTruthy(actual);
   void toBeFalse(actual);
@@ -34,6 +35,7 @@ abstract class Matchers {
   void notToContain(actual, expected);
   void notToBe(actual, expected);
   void notToBeA(actual, expected);
+  void notToBeAnInstanceOf(actual, expected);
   void toReturnNormally(actual);
   void toBeUndefined(actual);
   void notToHaveBeenCalled(actual);

--- a/test/src/unittest_backend_test.dart
+++ b/test/src/unittest_backend_test.dart
@@ -3,6 +3,9 @@ part of guinness_test;
 assertTrue(Function fn) => expect(fn, returnsNormally);
 assertFalse(Function fn) => expect(fn, throws);
 
+class TestClass {
+}
+
 testUnitTestBackend(){
   group("[ExclusiveItVisitor]", () {
     test("return true when a suite has an iit", () {
@@ -134,6 +137,11 @@ testUnitTestBackend(){
       assertTrue(() => matchers.toBeA(2, num));
     });
 
+    test("toBeAnInstanceOf", (){
+      assertFalse(() => matchers.toBeAnInstanceOf("blah", TestClass));
+      assertTrue(() => matchers.toBeAnInstanceOf(new TestClass(), TestClass));
+    });
+
     test("toThrow", (){
       assertTrue(() => matchers.toThrow(() => throw "Wow!"));
       assertFalse(() => matchers.toThrow((){}));
@@ -172,6 +180,12 @@ testUnitTestBackend(){
           () => throw new ArgumentError("123"),
           type: UnsupportedError,
           message: "123"));
+      assertFalse(() => matchers.toThrowWith(
+          () => throw new ArgumentError("123"),
+          anInstanceOf: UnsupportedError));
+      assertTrue(() => matchers.toThrowWith(
+          () => throw new ArgumentError("123"),
+          anInstanceOf: ArgumentError));
     });
 
     test("toBeFalsy", (){
@@ -311,6 +325,11 @@ testUnitTestBackend(){
     test("notToBeA", (){
       assertTrue(() => matchers.notToBeA(2, String));
       assertFalse(() => matchers.notToBeA(2, num));
+    });
+
+    test("notToBeAnInstanceOf", (){
+      assertTrue(() => matchers.notToBeAnInstanceOf(2, TestClass));
+      assertFalse(() => matchers.notToBeAnInstanceOf(new TestClass(), TestClass));
     });
 
     test("toReturnNormally", (){


### PR DESCRIPTION
Since `isSubtypeOf` is supported in Dart2JS, the `toBeA` and `toThrowWith(type:)` matchers do not work when compiled to JS.  The `toBeAnInstanceOf` matcher is added to deal with it. It does a simpler check, which works in Dart2JS.
