### PR TITLE
update the `toThrowWith` matcher to accept a callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.8
+
+- Update the `toThrowWith` matcher to accept a callback to run custom matchers against the thrown exception
+- Cleanup
+
+
 # v0.1.7 (2014-06-02)
 
 - Update the `toThrowWith` matcher to accept a pattern to match the message

--- a/example/example.dart
+++ b/example/example.dart
@@ -22,6 +22,9 @@ main(){
       expect(()=> throw "BOOM").toThrowWith(message: new RegExp("B[O]{2}M"));
       expect(()=> throw new TestClass()).toThrowWith(anInstanceOf: TestClass);
       expect(()=> throw new TestClass()).toThrowWith(type: TestClass);
+      expect(()=> throw new TestClass()).toThrowWith(where: (e) {
+        expect(e).toBeDefined();
+      });
       expect(false).toBeFalsy();
       expect(null).toBeFalsy();
       expect(true).toBeTruthy();

--- a/lib/src/common/expect.dart
+++ b/lib/src/common/expect.dart
@@ -42,15 +42,19 @@ class Expect {
    * - anInstanceOf: the thrown exception is an instance of `anInstanceOf`.
    * - type: the thrown exception is a subtype of `type`.
    * - message: the thrown exception's message matches the provided pattern.
+   * - where: the thrown exception matches all the expectations in the provided `where`.
    *
    * # Examples
    *
    *    expect(()=> throw "Invalid Argument").toThrowWith(message: "Invalid");
    *    expect(()=> throw new InvalidArgument()).toThrowWith(anInstanceOf: InvalidArgument);
    *    expect(()=> throw new InvalidArgument()).toThrowWith(type: ArgumentException);
+   *    expect(()=> throw new InvalidArgument()).toThrowWith(where: (e) {
+   *      expect(e).toBeAnInstanceOf(InvalidArgument)
+   *    });
    */
-  void toThrowWith({Type anInstanceOf, Type type, Pattern message}) =>
-      _m.toThrowWith(actual, anInstanceOf: anInstanceOf, type: type, message: message);
+  void toThrowWith({Type anInstanceOf, Type type, Pattern message, Function where}) =>
+      _m.toThrowWith(actual, anInstanceOf: anInstanceOf, type: type, message: message, where: where);
 
   void toBeFalsy() => _m.toBeFalsy(actual);
   void toBeTruthy() => _m.toBeTruthy(actual);

--- a/lib/src/common/interfaces.dart
+++ b/lib/src/common/interfaces.dart
@@ -19,7 +19,7 @@ abstract class Matchers {
   void toBeAnInstanceOf(actual, expected);
   @Deprecated("toThrow() API is going to change to conform with toThrowWith()")
   void toThrow(actual, message);
-  void toThrowWith(actual, {Type anInstanceOf, Type type, Pattern message});
+  void toThrowWith(actual, {Type anInstanceOf, Type type, Pattern message, Function where});
   void toBeFalsy(actual);
   void toBeTruthy(actual);
   void toBeFalse(actual);

--- a/test/src/unittest_backend_test.dart
+++ b/test/src/unittest_backend_test.dart
@@ -186,6 +186,16 @@ testUnitTestBackend(){
       assertTrue(() => matchers.toThrowWith(
           () => throw new ArgumentError("123"),
           anInstanceOf: ArgumentError));
+      assertTrue(() {
+        matchers.toThrowWith(() => throw new ArgumentError("123"), where: (e) {
+          expect(e.message, equals("123"));
+        });
+      });
+      assertFalse(() {
+        matchers.toThrowWith(() => throw new ArgumentError("123"), where: (e) {
+          expect(e.message, equals("456"));
+        });
+      });
     });
 
     test("toBeFalsy", (){


### PR DESCRIPTION
update the `toThrowWith` matcher to accept a callback to run custom matchers against the the thrown exception
