### PR TITLE
feat(karma integration): add a file to init specs to improve karma integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Handle afterEach blocks that throw.
 - When an `it` returns normally, and an `afterEach` throws, the error throw by the `afterEach` block is returned.
 
 
+Add `init_specs.dart` to improve Karma integration. Since the standard auto initialization of specs does not work with Karma, you had to call `guinness.initSpecs()` manually.
+Now, you can just include the init file, as follows:
+
+    files: [
+      "test/main1_test.dart",
+      "test/main2_test.dart",
+      "packages/guinness/init_specs.dart",
+      {pattern: '**/*.dart', watched: true, included: false, served: true}
+    ]
+
+
 # v0.1.9 (2014-06-18)
 
 Add extra information about the test suite.

--- a/README.md
+++ b/README.md
@@ -242,11 +242,14 @@ Usually, you don't need to worry about it.
 
 ## Guinness and Karma
 
-Guinness works with Karma. Just configure `karmaDartImports`:
+Guinness works with Karma. Just include `initSpecs`, as follows:
 
-    karmaDartImports: {
-      guinness: 'package:guinness/guinness_html.dart'
-    }
+    files: [
+      "test/main1_test.dart",
+      "test/main2_test.dart",
+      "packages/guinness/init_specs.dart",
+      {pattern: '**/*.dart', watched: true, included: false, served: true}
+    ]
 
 ## Status
 

--- a/lib/init_specs.dart
+++ b/lib/init_specs.dart
@@ -1,0 +1,8 @@
+library guiness_init_specs;
+
+import 'package:guinness/guinness.dart';
+
+main() {
+  guinness.autoInit = false;
+  guinness.initSpecs();
+}


### PR DESCRIPTION
Since the standard auto initialization of specs does not work with Karma, you had to call `guinness.initSpecs()` manually.

Now, you can just include the init file, as follows:

```
files: [
  "test/main1_test.dart",
  "test/main2_test.dart",
  "packages/guinness/init_specs.dart",
  {pattern: '**/*.dart', watched: true, included: false, served: true}
]
```
