### PR TITLE
feat(toThrowWith): add support for 'where' boolean return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.1.15
+
+- The `where` argument to `toThrowWith` could be a function returning a boolean:
+
+    `expect(testedClosure).toThrowWith(where: (e) => e is NoSuchMethodError);`
+
+  will pass iff executing the `testClosure` throws a `NoSuchMethodError` exception.
+
 # v0.1.14 (2014-08-02)
 
 - Improve the handling of Shadow DOM. The `toHaveText` matcher now handles Shadow DOM with multiple insertion points.
@@ -16,7 +24,7 @@
 - Add numeric matchers:
   - `toBeLessThan(expected)`,
   - `toBeGreaterThan(expected)`,
-  - `toBeCloseTo(expected, precision)` - assert than the value is within `expected ± (10^-precision)/2` 
+  - `toBeCloseTo(expected, precision)` - assert than the value is within `expected ± (10^-precision)/2`
 
 # v0.1.10 (2014-06-23)
 

--- a/lib/src/common/expect.dart
+++ b/lib/src/common/expect.dart
@@ -45,7 +45,9 @@ class Expect {
    * - anInstanceOf: the thrown exception is an instance of `anInstanceOf`.
    * - type: the thrown exception is a subtype of `type`.
    * - message: the thrown exception's message matches the provided pattern.
-   * - where: the thrown exception matches all the expectations in the provided `where`.
+   * - where:
+   *   - the thrown exception matches all the expectations in the provided `where`,
+   *   - the expectation fails when `where()` returns false
    *
    * # Examples
    *
@@ -55,6 +57,7 @@ class Expect {
    *    expect(()=> throw new InvalidArgument()).toThrowWith(where: (e) {
    *      expect(e).toBeAnInstanceOf(InvalidArgument)
    *    });
+   *   expect(()=> throw new InvalidArgument()).toThrowWith(where: (e) => e is InvalidArgument);
    */
   void toThrowWith({Type anInstanceOf, Type type, Pattern message, Function where}) =>
       _m.toThrowWith(actual, anInstanceOf: anInstanceOf, type: type, message: message, where: where);

--- a/lib/src/common/unittest_backend.dart
+++ b/lib/src/common/unittest_backend.dart
@@ -220,8 +220,7 @@ class WhereMatcher extends unit.Matcher {
 
   bool matches(obj, Map matchState) {
     try {
-      _where(obj);
-      return true;
+      return _where(obj) != false;
     } on unit.TestFailure catch (e) {
       matchState["nestedMatcherFailure"] = e;
       return false;

--- a/test/src/unittest_backend_test.dart
+++ b/test/src/unittest_backend_test.dart
@@ -168,13 +168,23 @@ testUnitTestBackend(){
           expect(e.message, equals("456"));
         });
       });
+      assertTrue(() {
+        matchers.toThrowWith(
+            () => throw new ArgumentError("123"),
+            where: (e) => e.message == "123");
+      });
+      assertFalse(() {
+        matchers.toThrowWith(
+            () => throw new ArgumentError("123"),
+            where: (e) => e.message == "456");
+      });
 
       skipDart2Js(() {
         assertTrue(() => matchers.toThrowWith(
-                () => throw new ArgumentError(),
+            () => throw new ArgumentError(),
             type: ArgumentError));
         assertFalse(() => matchers.toThrowWith(
-                () => throw new ArgumentError(),
+            () => throw new ArgumentError(),
             type: UnsupportedError));
       });
     });


### PR DESCRIPTION
@vsavkin I had the impl ready (one liner). I've added tests & doc.
