### PR TITLE
New html matchers: toContainText & notToContainText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pubspec.lock
 packages
 node_modules
+*.iml

--- a/lib/src/html/expect.dart
+++ b/lib/src/html/expect.dart
@@ -7,6 +7,7 @@ class Expect extends gns.Expect {
 
   void toHaveHtml(expected) => _m.toHaveHtml(actual, expected);
   void toHaveText(expected) => _m.toHaveText(actual, expected);
+  void toContainText(expected) => _m.toContainText(actual, expected);
   void toHaveClass(cls) => _m.toHaveClass(actual, cls);
   void toHaveAttribute(name, [value = null]) => _m.toHaveAttribute(actual, name, value);
   void toEqualSelect(options) => _m.toEqualSelect(actual, options);
@@ -20,6 +21,7 @@ class NotExpect extends gns.NotExpect {
 
   void toHaveHtml(expected) => _m.notToHaveHtml(actual, expected);
   void toHaveText(expected) => _m.notToHaveText(actual, expected);
+  void toContainText(expected) => _m.notToContainText(actual, expected);
   void toHaveClass(cls) => _m.notToHaveClass(actual, cls);
   void toHaveAttribute(name) => _m.notToHaveAttribute(actual, name);
 

--- a/lib/src/html/interfaces.dart
+++ b/lib/src/html/interfaces.dart
@@ -3,12 +3,14 @@ part of guinness_html;
 abstract class HtmlMatchers {
   void toHaveHtml(actual, expected);
   void toHaveText(actual, expected);
+  void toContainText(actual, expected);
   void toHaveClass(actual, cls);
   void toHaveAttribute(actual, name, [value]);
   void toEqualSelect(actual, options);
 
   void notToHaveHtml(actual, expected);
   void notToHaveText(actual, expected);
+  void notToContainText(actual, expected);
   void notToHaveClass(actual, cls);
   void notToHaveAttribute(actual, name);
 }

--- a/lib/src/html/unittest_html_matchers.dart
+++ b/lib/src/html/unittest_html_matchers.dart
@@ -15,6 +15,10 @@ class UnitTestMatchersWithHtml extends gns.UnitTestMatchers implements HtmlMatch
       unit.expect(htmlUtils.elementText(actual),
                   unit.equals(expected));
 
+  void toContainText(actual, expected) =>
+      unit.expect(htmlUtils.elementText(actual),
+                  unit.contains(expected));
+
   void toHaveClass(actual, cls) =>
       unit.expect(actual.classes.contains(cls),
                   true,
@@ -49,6 +53,11 @@ class UnitTestMatchersWithHtml extends gns.UnitTestMatchers implements HtmlMatch
   void notToHaveText(actual, expected) =>
       unit.expect(htmlUtils.elementText(actual),
                   unit.isNot(unit.equals(expected)));
+
+  void notToContainText(actual, expected) =>
+      unit.expect(htmlUtils.elementText(actual),
+                  unit.isNot(unit.contains(expected)));
+
 
   void notToHaveClass(actual, cls) =>
       unit.expect(actual.classes.contains(cls),

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "url": "https://github.com/vsavkin/guinness.git"
   },
   "devDependencies": {
-    "karma" : "~0.12.0",
-    "karma-dart" : "~0.2.6",
+    "karma": "~0.12.0",
+    "karma-dart": "~0.2.6",
     "karma-chrome-launcher": "~0.1.3",
     "karma-phantomjs-launcher": "~0.1.3",
     "karma-junit-reporter": "~0.2.1",
-    "karma-jasmine" : "~0.1.5"
+    "karma-jasmine": "~0.1.5"
   }
 }

--- a/test/src/unittest_backend_test.dart
+++ b/test/src/unittest_backend_test.dart
@@ -229,6 +229,12 @@ testUnitTestBackend(){
       assertFalse(() => matchers.toHaveText(div, "invalid"));
     });
 
+    test("toContainText", (){
+      final div = new html.DivElement()..innerHtml = "some expected text";
+      assertTrue(() => matchers.toContainText(div, "expected"));
+      assertFalse(() => matchers.toContainText(div, "invalid"));
+    });
+
     test("toHaveClass", (){
       final div = new html.DivElement();
       div.classes.add("one");
@@ -366,6 +372,12 @@ testUnitTestBackend(){
       final div = new html.DivElement()..innerHtml = "expected";
       assertFalse(() => matchers.notToHaveText(div, "expected"));
       assertTrue(() => matchers.notToHaveText(div, "invalid"));
+    });
+
+    test("notToContainText", (){
+      final div = new html.DivElement()..innerHtml = "some expected test";
+      assertFalse(() => matchers.notToContainText(div, "expected"));
+      assertTrue(() => matchers.notToContainText(div, "invalid"));
     });
 
     test("notToHaveClass", (){


### PR DESCRIPTION
Hi, I found that toHaveText html matcher doesn't really work as expected with html like this:
```
<div>
  Some text
</div>
```

Because it compares inner text exactly, including whitespaces. I added `toContainText` to deal with this problem. It's also useful for many other use cases. Hope you like it :)

Best,
Kris