### PR TITLE
Add support for the fit() / fdescribe() syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.17 ()
+
+- Add `fit()` and `fdescribe()` to create focused specs and suite - introduced in Jasmine 2.1.
+  `fit()` / ` fdescribe()` are aliases for `iit()` / `ddescribe()`
+
 # v0.1.16 (2014-10-29)
 
 - Add `toHaveSameProps` matcher.

--- a/lib/src/common/syntax.dart
+++ b/lib/src/common/syntax.dart
@@ -15,6 +15,7 @@ void xit(name, [Function fn]) =>
 void iit(name, [Function fn]) =>
     guinness._context.addIt(name.toString(), fn, excluded: false, exclusive: true);
 
+void fit(name, [Function fn]) => iit(name, fn);
 
 void describe(name, [Function fn]) =>
     guinness._context.addDescribe(name.toString(), fn, excluded: false, exclusive: false);
@@ -24,6 +25,8 @@ void xdescribe(name, [Function fn]) =>
 
 void ddescribe(name, [Function fn]) =>
     guinness._context.addDescribe(name.toString(), fn, excluded: false, exclusive: true);
+
+void fdescribe(name, [Function fn]) => ddescribe(name, fn);
 
 Expect expect(actual, [matcher]) {
   final expect = new Expect(actual);

--- a/test/src/syntax_test.dart
+++ b/test/src/syntax_test.dart
@@ -41,6 +41,17 @@ testSyntax(){
       });
     });
 
+    group("[fdescribe]", (){
+      test("adds a describe to the current describe block with exclusive set to true", (){
+        guinness.fdescribe("new fdescribe", (){});
+
+        final actualDescribe = context.suite.children.first;
+
+        expect(actualDescribe.name, equals("DDESCRIBE: new fdescribe"));
+        expect(actualDescribe.exclusive, isTrue);
+      });
+    });
+
     group("[it]", (){
       test("adds an `it` to the current describe block", (){
         guinness.it("new it", (){});
@@ -71,6 +82,17 @@ testSyntax(){
         final actualIt = context.suite.children.first;
 
         expect(actualIt.name, equals("new iit"));
+        expect(actualIt.exclusive, isTrue);
+      });
+    });
+
+    group("[fit]", (){
+      test("adds an `it` to the current describe block with exclusive set to true", (){
+        guinness.fit("new fit", (){});
+
+        final actualIt = context.suite.children.first;
+
+        expect(actualIt.name, equals("new fit"));
         expect(actualIt.exclusive, isTrue);
       });
     });


### PR DESCRIPTION
To match Jasmine 2.1, see http://pivotallabs.com/new-key-features-
jasmine-2-1/
